### PR TITLE
(fix) Style fixes in xRange.js and spec.js

### DIFF
--- a/spec.js
+++ b/spec.js
@@ -3,150 +3,150 @@ const expect = require('chai').expect;
 
 const xRange = require('./index.js');
 
-var increment = val => val+1;
+var increment = val => val + 1;
 var same = (val) => val;
 var double = (val) => 2 * val;
 var isEven = val => val % 2 === 0;
-var sum = (a,b) => a+b;
-var sumWithIndex = (acc,val,index) => acc + val + index;
+var sum = (a, b) => a + b;
+var sumWithIndex = (acc, val, index) => acc + val + index;
 
 
 describe('xRange constructor', function() {
   
   it ('includes start but not end value', function() {
-    var r = new xRange(0,5,1);
-    var target = [0,1,2,3,4];
+    var r = new xRange(0, 5, 1);
+    var target = [0, 1, 2, 3, 4];
     expect(r.toArray()).to.deep.equal(target);    
-  })
+  });
 
   it ('allows positive increments', function() {
-    var r = new xRange(0,5,2);
-    var target = [0,2,4];
+    var r = new xRange(0, 5, 2);
+    var target = [0, 2, 4];
     expect(r.toArray()).to.deep.equal(target);    
-  })
+  });
 
   it ('allows negative increments', function() {
-    var r = new xRange(5,-1,-2);
-    var target = [5,3,1];
+    var r = new xRange(5, -1, -2);
+    var target = [5, 3, 1];
     expect(r.toArray()).to.deep.equal(target);    
-  })
+  });
 
   it ('empty array when start = end', function() {
-    var r = new xRange(5,5);
+    var r = new xRange(5, 5);
     var target = [];
     expect(r.toArray()).to.deep.equal(target);    
-  })
+  });
 
   it ('length is zero when increment is zero', function() {
-    var r = new xRange(1,10,0);
+    var r = new xRange(1, 10, 0);
     var target = [];
     expect(r.toArray()).to.deep.equal(target);    
   })
 
   it ('length is zero when increment would create ininite iterations', function() {
-    var r = new xRange(1,10,-1);
+    var r = new xRange(1, 10, -1);
     var target = [];
     expect(r.toArray()).to.deep.equal(target);    
-  })
+  });
 
   it ('allows for only 1 argument', function() {
     var r = new xRange(4);
-    var target = [0,1,2,3];
+    var target = [0, 1, 2, 3];
     expect(r.toArray()).to.deep.equal(target);    
-  })
+  });
 
     it ('allows for only 2 arguments', function() {
-    var r = new xRange(2,4);
-    var target = [2,3];
+    var r = new xRange(2, 4);
+    var target = [2, 3];
     expect(r.toArray()).to.deep.equal(target);    
-  })
+  });
 
-})
+});
 
 
 describe('xMap', function() {
   
   it ('is lazy', function() {
-    var r = new xRange(0,5,1);
+    var r = new xRange(0, 5, 1);
     var result = r.xMap(same);
     expect(result).to.not.be.an('array');    
-  })
+  });
 
   it ('maps cb(value,index)', function() {
-    var r = new xRange(0,5,1);
+    var r = new xRange(0, 5, 1);
     var result = r.xMap(increment).xMap(increment).xMap(same).toArray();
-    var target = [2,3,4,5,6]
+    var target = [2, 3, 4, 5, 6];
     expect(result).to.deep.equal(target);   
-  })
+  });
 
   it ('calls lazy maps in order', function() {
-    var r = new xRange(0,3,1);
+    var r = new xRange(0, 3, 1);
     var result = r.xMap(increment).xMap(double).xMap(increment).toArray();
-    var target = [3,5,7]
+    var target = [3, 5, 7];
     expect(result).to.deep.equal(target);   
-  })
+  });
 
-})
+});
 
 describe('map', function() {
   
   it ('returns array', function() {
-    var r = new xRange(0,5,1);
+    var r = new xRange(0, 5, 1);
     var result = r.map(same);
     expect(result).to.be.an('array');    
-  })
+  });
 
   it ('maps cb(value,index)', function() {
-    var r = new xRange(0,3,1);
-    var result = r.map(increment)
-    var target = [1,2,3]
+    var r = new xRange(0, 3, 1);
+    var result = r.map(increment);
+    var target = [1, 2, 3];
     expect(result).to.deep.equal(target);   
-  })
+  });
 
   it ('calls lazy map first', function() {
-    var r = new xRange(0,3,1);
-    var result = r.xMap(double).map(increment)
-    var target = [1,3,5]
+    var r = new xRange(0, 3, 1);
+    var result = r.xMap(double).map(increment);
+    var target = [1, 3, 5];
     expect(result).to.deep.equal(target);   
-  })
+  });
 
-})
+});
 
 describe('filter', function() {
 
   it ('filters cb(value,index)', function() {
-    var r = new xRange(0,8,1);
+    var r = new xRange(0, 8, 1);
     var result = r.filter(isEven);
-    var target = [0,2,4,6];
+    var target = [0, 2, 4, 6];
     expect(result).to.deep.equal(target);   
-  })
+  });
 
   it ('calls lazy map first', function() {
-    var r = new xRange(0,4,1);
+    var r = new xRange(0, 4, 1);
     var result = r.xMap(double).filter(isEven);
-    var target = [0,2,4,6]
+    var target = [0, 2, 4, 6];
     expect(result).to.deep.equal(target);   
-  })
+  });
 
-})
+});
 
 describe('reduce', function() {
 
   it ('reduces cb(acc,value,index)', function() {
-    var r = new xRange(0,5,1);
+    var r = new xRange(0, 5, 1);
     var result = r.reduce(sum);
     expect(result).to.equal(10);
     var result = r.reduce(sumWithIndex);
     expect(result).to.equal(20);  
-  })
+  });
 
   it ('calls lazy map first', function() {
-    var r = new xRange(0,5,1);
+    var r = new xRange(0, 5, 1);
     var result = r.xMap(double).reduce(sum);
     expect(result).to.equal(20);
     var result = r.xMap(double).reduce(sumWithIndex);
     expect(result).to.equal(30);  
-  })
+  });
 
-})
+});
 

--- a/xRange.js
+++ b/xRange.js
@@ -88,9 +88,6 @@ xRange.prototype.toArray = function() {
   return this.map(v => v);
 }
 
-
-
-
 // xRange.prototype.show = function(cb) {
 //   var toShow = new Array(this.length);
 //   this.forEach((v,i) => {
@@ -104,18 +101,3 @@ xRange.prototype.toArray = function() {
 // var print = (v) => console.log(v);
 
 // var r = new xRange(1,4,3);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/xRange.js
+++ b/xRange.js
@@ -3,7 +3,7 @@ module.exports = xRange;
 // Edge case increment === 0...
 // Note that will not make infinite series on forEach/reduce
 //  (since increment will be negative or zero)
-function xRange(start,end,increment) {
+function xRange(start, end, increment) {
   if (end === undefined) {
     this.start = 0;
     this.end = start;
@@ -26,7 +26,7 @@ xRange.prototype.next = function() {
   var toReturn = this.current;
   // call each lazy map
   for (var i = 0; i < this.maps.length; i++) {
-    toReturn = this.maps[i](toReturn,this.currentIndex);
+    toReturn = this.maps[i](toReturn, this.currentIndex);
   }
   this.currentIndex ++;
   this.current += this.increment;
@@ -39,7 +39,7 @@ xRange.prototype.forEach = function(cb) {
   this.current = this.start;
   this.currentIndex = 0;
   for (var i = 0; i < this.length; i++) {
-    cb(this.next(),i);
+    cb(this.next(), i);
   }
   this.maps = [];
 }
@@ -52,14 +52,14 @@ xRange.prototype.xMap = function(cb) {
 
 xRange.prototype.map = function(cb) {
   var toReturn = new Array(this.length);
-  this.forEach((val,index) => {
-    toReturn[index] = cb(val,index);
+  this.forEach((val, index) => {
+    toReturn[index] = cb(val, index);
   })
   return toReturn;
 }
 
 //cb(acc,val,index)
-xRange.prototype.reduce = function(cb,acc) {
+xRange.prototype.reduce = function(cb, acc) {
   this.current = this.start;
   var i = 0;
   if (acc === undefined) {
@@ -67,7 +67,7 @@ xRange.prototype.reduce = function(cb,acc) {
     acc = this.next();
   }
   while (i < this.length) {
-    acc = cb(acc,this.next(),i);
+    acc = cb(acc, this.next(), i);
     i++;
   }
   this.maps = [];
@@ -76,8 +76,8 @@ xRange.prototype.reduce = function(cb,acc) {
 
 xRange.prototype.filter = function(cb) {
   var toReturn = [];
-  this.forEach((val,index) => {
-    if (cb(val,index)) {
+  this.forEach((val, index) => {
+    if (cb(val, index)) {
       toReturn.push(val);
     }
   })

--- a/xRange.js
+++ b/xRange.js
@@ -1,8 +1,5 @@
 module.exports = xRange;
 
-console.log('xRange.js got called')
-
-
 // Edge case increment === 0...
 // Note that will not make infinite series on forEach/reduce
 //  (since increment will be negative or zero)


### PR DESCRIPTION
## Code Clean Up:

This pull request:

- Removes a stray `console.log()` from `xRange.js`.
- Adds padding to all function parameters/arguments.
- Adds padding to all mathematical operators.
- Adds semi-colons where they are missing.